### PR TITLE
StorageUnits

### DIFF
--- a/src/json/wiki.json
+++ b/src/json/wiki.json
@@ -6860,7 +6860,7 @@
         "Humpback",
         "Lightpack 2.0"
       ],
-      "Content": ""
+      "Content": "Storage units expand a bot's inventory size by their listed amount plus the 5 storage spaces that all bots have without any additional storage.\n[[Table]]Name|Storage|Mass|Equip Slots|Coverage|Max. Integrity||[[Sml. Storage Unit]]|3|5|1|25|150||[[Med. Storage Unit]]|5|10|1|25|250||[[Lrg. Storage Unit]]|10|20|1|25|350||[[Hcp. Storage Unit]]|15|40|1|25|500||[[Huge Storage Unit]]|20|80|1|25|600||[[Cargo Storage Unit]]|25|140|2|50|1000||[[Humpback]]|30|200|2|160|400||[[Lightpack 2.0]]|35|5|3|45|*500[[/Table]]"
     },
     {
       "Name": "System Guards",

--- a/src/json/wiki.json
+++ b/src/json/wiki.json
@@ -6860,7 +6860,7 @@
         "Humpback",
         "Lightpack 2.0"
       ],
-      "Content": "Storage units expand a bot's inventory size by their listed amount plus the 5 storage spaces that all bots have without any additional storage.\n[[Table]]Name|Storage|Mass|Equip Slots|Coverage|Max. Integrity||[[Sml. Storage Unit]]|3|5|1|25|150||[[Med. Storage Unit]]|5|10|1|25|250||[[Lrg. Storage Unit]]|10|20|1|25|350||[[Hcp. Storage Unit]]|15|40|1|25|500||[[Huge Storage Unit]]|20|80|1|25|600||[[Cargo Storage Unit]]|25|140|2|50|1000||[[Humpback]]|30|200|2|160|400||[[Lightpack 2.0]]|35|5|3|45|*500[[/Table]]"
+      "Content": ""
     },
     {
       "Name": "System Guards",

--- a/src/json/wiki.json
+++ b/src/json/wiki.json
@@ -6860,7 +6860,7 @@
         "Humpback",
         "Lightpack 2.0"
       ],
-      "Content": "Storage units expand a bot's inventory size by their listed amount plus the 5 storage spaces that all bots have without any additional storage.\n[[Table]]Name|Storage|Mass|Equip Slots|Coverage|Max. Integrity||[[Sml. Storage Unit]]|3|5|1|25|150||[[Med. Storage Unit]]|5|10|1|25|250||[[Lrg. Storage Unit]]|10|20|1|25|350||[[Hcp. Storage Unit]]|15|40|1|25|500||[[Huge Storage Unit]]|20|80|1|25|600||[[Cargo Storage Unit]]|25|140|2|50|1000||[[Humpback]]|30|200|2|160|400||[[Lightpack 2.0]]|35|5|3|45|*500[[/Table]]"
+      "Content": "Storage units expand a bot's inventory size by their listed amount plus the 5 storage spaces that all bots have without any additional storage.[[Table]]Name|Storage|Mass|Equip Slots|Coverage|Max. Integrity||[[Sml. Storage Unit]]|3|5|1|25|150||[[Med. Storage Unit]]|5|10|1|25|250||[[Lrg. Storage Unit]]|10|20|1|25|350||[[Hcp. Storage Unit]]|15|40|1|25|500||[[Huge Storage Unit]]|20|80|1|25|600||[[Cargo Storage Unit]]|25|140|2|50|1000||[[Humpback]]|30|200|2|160|400||[[Lightpack 2.0]]|35|5|3|45|*500[[/Table]]"
     },
     {
       "Name": "System Guards",


### PR DESCRIPTION
Adds a brief description and comparison table to https://noemica.github.io/cog-minder/wiki.html#Storage%20Units 

Text:

`Storage units expand a bot's inventory size by their listed amount plus the 5 storage spaces that all bots have without any additional storage.[[Table]]Name|Storage|Mass|Equip Slots|Coverage|Max. Integrity||[[Sml. Storage Unit]]|3|5|1|25|150||[[Med. Storage Unit]]|5|10|1|25|250||[[Lrg. Storage Unit]]|10|20|1|25|350||[[Hcp. Storage Unit]]|15|40|1|25|500||[[Huge Storage Unit]]|20|80|1|25|600||[[Cargo Storage Unit]]|25|140|2|50|1000||[[Humpback]]|30|200|2|160|400||[[Lightpack 2.0]]|35|5|3|45|*500[[/Table]]`